### PR TITLE
Refactor: Unify path configuration and update usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ exclude = [
 pythonpath = ["."]
 testpaths = ["tests", "shared/tests", "services/*/tests"]
 python_files = ["test_*.py", "*_test.py"]
-addopts = "--cov=aclarai_shared --cov-report=term-missing --cov-report=xml --cov-config=pyproject.toml --import-mode=importlib"
+addopts = "--import-mode=importlib" # Temporarily removed coverage flags
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
 ]

--- a/services/scheduler/aclarai_scheduler/vault_sync.py
+++ b/services/scheduler/aclarai_scheduler/vault_sync.py
@@ -31,10 +31,10 @@ class VaultSyncJob:
         self.graph_manager = Neo4jGraphManager(self.config)
         self.block_parser = BlockParser()
         # Vault paths from config
-        self.vault_path = Path(self.config.vault_path)
+        self.vault_path = Path(self.config.paths.vault) # Use paths.vault
         self.tier1_path = self.vault_path / self.config.paths.tier1
-        self.tier2_path = self.vault_path / self.config.paths.tier2
-        self.tier3_path = self.vault_path / self.config.paths.tier3
+        self.tier2_path = self.vault_path / self.config.paths.tier2 # Already correct
+        self.tier3_path = self.vault_path / self.config.paths.tier3 # Already correct
 
     def run_sync(self) -> Dict[str, Any]:
         """

--- a/shared/aclarai_shared/tier3_concept/writer.py
+++ b/shared/aclarai_shared/tier3_concept/writer.py
@@ -27,10 +27,10 @@ class ConceptFileWriter:
         """Initialize the concept file writer."""
         self.config = config or aclaraiConfig()
         # Get the concepts directory from configuration
-        vault_path = Path(self.config.vault_path)
+        vault_path = Path(self.config.paths.vault) # Use paths.vault
         concepts_path = (
-            self.config.paths.concepts or "concepts"
-        )  # Default to "concepts" if not set
+            self.config.paths.tier3 or "concepts"
+        )  # Default to "concepts" if not set, using tier3
         self.concepts_dir = vault_path / concepts_path
         logger.debug(
             f"Initialized ConceptFileWriter with concepts directory: {self.concepts_dir}",


### PR DESCRIPTION
This commit addresses inconsistencies in path management by:

1.  Eliminating the old `PathsConfig` class.
2.  Renaming and enhancing `VaultPaths` to `PathsConfig`, making it the single source of truth for path configurations. This class now includes `vault`, `settings`, `tier1`, `tier2`, `tier3`, and `logs` fields with user-friendly defaults like "conversations", "summaries", and "concepts".
3.  Updated `aclaraiConfig` to use the new `PathsConfig` and adjusted its `from_env` method to populate this unified object.
4.  Modified `VaultSyncJob` (in `services/scheduler/aclarai_scheduler/vault_sync.py`) to use the updated path structure (e.g., `config.paths.vault`, `config.paths.tier2`).
5.  Updated `ConceptFileWriter` (in `shared/aclarai_shared/tier3_concept/writer.py`) to use `config.paths.tier3`.
6.  Confirmed `Tier2SummaryAgent` (in `shared/aclarai_shared/tier2_summary/agent.py`) already correctly uses `config.paths.tier2` where necessary.
7.  Updated tests in `tests/test_vault_sync.py` to reflect the changes in `PathsConfig` structure, specifically how mock configurations are created.

Currently, there are unresolved test failures in `tests/test_vault_sync.py` related to `ModuleNotFoundError: No module named 'aclarai_scheduler'`. This seems to be an issue with Python's import resolution or pytest's test discovery in the monorepo structure when tests in the top-level `tests` directory try to import modules from the `services` subdirectories.

Further investigation is needed to correctly configure the test environment or adjust import paths/patch targets to allow these tests to pass. The `pyproject.toml` was temporarily modified to remove pytest coverage arguments that were causing initial test execution errors.