### PR TITLE
feat: Implement Entailment Agent with tests and improved LLM init

### DIFF
--- a/docs/components/entailment_evaluation_agent.md
+++ b/docs/components/entailment_evaluation_agent.md
@@ -1,0 +1,61 @@
+# Entailment Evaluation Agent
+
+The Entailment Evaluation Agent is responsible for assessing whether a given source text logically entails a claim derived from it. This is a crucial step in the claim processing pipeline to ensure the quality and factual grounding of claims.
+
+## Purpose
+
+This agent determines the degree to which a `source` text (e.g., a block of conversation, a document sentence) supports a given `claim` text. The output is an `entailed_score`, a float between 0.0 and 1.0.
+
+- **1.0**: The source perfectly entails the claim.
+- **0.5**: The source partially supports or is related to the claim but does not fully entail it.
+- **0.0**: The source does not entail the claim at all, or contradicts it.
+- **null**: The evaluation failed after retries (e.g., LLM error, timeout).
+
+## Agent Implementation
+
+- **Class:** `services.aclarai-core.aclarai_core.agents.entailment_agent.EntailmentAgent`
+- **Framework:** Uses LlamaIndex's `CodeActAgent` to allow for multi-step reasoning and the use of tools for contextual understanding if needed.
+- **Configuration:**
+    - The agent's role for tool mapping is `"entailment_agent"` (configured in `tools.agent_tool_mappings`).
+    - The LLM model used by the agent can be configured under `model.claimify.entailment` in `aclarai.config.default.yaml` (or user overrides).
+
+## Prompt Structure
+
+The agent uses a dedicated prompt template: `shared/aclarai_shared/prompts/entailment_evaluation.yaml`.
+
+- **Inputs to Prompt:**
+    - `source_text`: The premise or source content.
+    - `claim_text`: The hypothesis or claim to be evaluated.
+- **Instructions to LLM:** The LLM is instructed to analyze the premise and hypothesis, use available tools (`neo4j_query_tool`, `vector_search_utterances`) if necessary for more context, and output a single float score representing the entailment level.
+
+Refer to the YAML file directly for the detailed system prompt and user template.
+
+## Process Flow
+
+1.  **Trigger:** The entailment evaluation process is typically triggered within the `DirtyBlockConsumer` after a source block in a Markdown file is identified as new or modified and has been synchronized with the Neo4j graph.
+2.  **Claim Retrieval:** The system fetches claims that originate from this source block and require entailment evaluation (e.g., `entailed_score` is `null` on the `[:ORIGINATES_FROM]` relationship, or the claim is marked for reprocessing).
+3.  **Agent Invocation:** For each such claim, the `EntailmentAgent.evaluate_entailment()` method is called with:
+    - `claim_id`
+    - `claim_text`
+    - `source_id` (the `aclarai:id` of the source block)
+    - `source_text` (the semantic content of the source block)
+4.  **Evaluation:** The agent processes the input using its configured LLM and prompt. It may use tools like `Neo4jQueryTool` or `VectorSearchTool` to gather more context (e.g., surrounding conversation, related utterances).
+5.  **Score Return:** The agent returns the `entailed_score` (or `None` on failure).
+
+## Output and Storage
+
+### 1. Neo4j Graph
+- The `entailed_score` (or `null` if evaluation failed) is stored as a property on the `[:ORIGINATES_FROM]` relationship connecting the `(:Claim {id: claim_id})` node to its source `(:Block {id: source_id})` node.
+- This update is performed by the `_update_entailment_score_in_neo4j` method in `DirtyBlockConsumer`.
+
+### 2. Tier 1 Markdown File
+- If the evaluation is successful (score is not `None`), the Markdown file containing the source block is updated:
+    - An HTML comment `<!-- aclarai:entailed_score=X.XX -->` (e.g., `<!-- aclarai:entailed_score=0.91 -->`) is added or updated. This comment is typically placed on the line immediately following the main `<!-- aclarai:id=source_id ... -->` comment of the source block.
+    - The version number in the source block's main comment (e.g., `ver=N`) is incremented by 1 (e.g., to `ver=N+1`).
+- These updates are performed by the `_update_markdown_with_entailment_score` method in `DirtyBlockConsumer`, using atomic file writes.
+- Claims with `null` entailment scores do not result in Markdown updates for this score.
+
+## Failure Handling
+- The `EntailmentAgent` includes a retry mechanism for LLM calls.
+- If evaluation fails after retries, the `entailed_score` will be `None`.
+- Downstream processes should handle `null` scores appropriately (e.g., by excluding such claims from further processing or promotion, as per `docs/arch/on-evaluation_agents.md`).

--- a/services/aclarai-core/aclarai_core/agents/entailment_agent.py
+++ b/services/aclarai-core/aclarai_core/agents/entailment_agent.py
@@ -1,0 +1,210 @@
+"""
+Agent for evaluating the entailment of a claim by its source.
+"""
+
+import logging
+from typing import Optional, Tuple
+
+from aclarai_shared.config import aclaraiConfig
+from aclarai_shared.tools.factory import ToolFactory
+from aclarai_shared.utils.prompt_loader import load_prompt_template
+
+# Using CodeActAgent as suggested by the issue's technical details for multi-step reasoning
+from llama_index.core.agent import CodeActAgent
+from llama_index.core.llms.llm import LLM
+from llama_index.core.tools import BaseTool
+from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+
+class EntailmentAgent:
+    """
+    Agent to assess if a source text logically entails a claim.
+    Uses a CodeActAgent to allow for multi-step reasoning and tool use.
+    """
+
+    def __init__(self, llm: LLM, tool_factory: ToolFactory, config: aclaraiConfig):
+        """
+        Initializes the EntailmentAgent.
+        """
+        self.llm = llm
+        self.config = config
+        self.tools: list[BaseTool] = tool_factory.get_tools_for_agent(
+            "entailment_agent"
+        )
+
+        # As per on-llm_interaction_strategy.md, agents can be CodeActAgent
+        # The issue also specifically mentions CodeActAgent for multi-step reasoning.
+        # CodeActAgent expects async tools if it's run in async mode.
+        # For simplicity in this synchronous agent, we'll ensure tools are adaptable.
+        # However, CodeActAgent itself is often used in an async context with agent_worker.arun
+        # For a synchronous evaluate_entailment, we might need to adjust or use ReActAgent
+        # if CodeActAgent proves difficult to run synchronously without an event loop.
+        # Let's try with CodeActAgent first as specified.
+        # If using synchronous `agent.chat()`, tools don't strictly need to be async.
+        self.agent = CodeActAgent.from_tools(
+            tools=self.tools,
+            llm=self.llm,
+            verbose=True,
+            # system_prompt will be part of the loaded prompt template
+        )
+        self.max_retries = self.config.processing.retries.get("max_attempts", 3)
+        self.tool_names = ", ".join([tool.metadata.name for tool in self.tools])
+
+    def evaluate_entailment(
+        self,
+        claim_id: str,
+        claim_text: str,
+        source_id: str,
+        source_text: str,
+        # source_filepath: str, # Added to plan, but not used by agent itself, consumer uses it.
+    ) -> Tuple[Optional[float], str]:
+        """
+        Evaluates the entailment of a given claim by its source.
+
+        Args:
+            claim_id: The unique identifier for the claim.
+            claim_text: The text of the claim (hypothesis).
+            source_id: The unique identifier for the source of the claim.
+            source_text: The text of the source from which the claim was derived (premise).
+            # source_filepath: Path to the markdown file of the source block.
+
+        Returns:
+            A tuple containing the entailment score (float between 0.0 and 1.0,
+            or None if an error occurs) and a string detailing any error messages or 'success'.
+        """
+        log_details = {
+            "service": "aclarai-core",
+            "filename_function_name": "entailment_agent.EntailmentAgent.evaluate_entailment",
+            "aclarai_id_claim": claim_id,
+            "aclarai_id_source": source_id,
+        }
+
+        try:
+            # Load and format the prompt from the external YAML file.
+            # The prompt template itself contains the system prompt and user instructions.
+            # The CodeActAgent will use the system prompt from the template if provided.
+            # The user part of the prompt is what we pass to agent.chat()
+            prompt_template_data = load_prompt_template(
+                "entailment_evaluation",
+                return_dict=True,  # Get the whole prompt structure
+                source_text=source_text,
+                claim_text=claim_text,
+                # Potentially inject tool descriptions if prompt needs them explicitly
+                # tool_descriptions = self.agent.get_tool_descriptions() # If needed
+            )
+
+            if (
+                not isinstance(prompt_template_data, dict)
+                or "template" not in prompt_template_data
+            ):
+                raise ValueError(
+                    "Prompt template for entailment_evaluation is not a dictionary or is missing 'template' key."
+                )
+
+            # The 'template' key holds the user-facing part of the prompt after formatting
+            user_prompt = prompt_template_data["template"]
+            system_prompt = prompt_template_data.get("system_prompt")
+
+            # Update agent's system prompt if provided by the loaded template
+            if system_prompt:
+                self.agent.update_prompts({"agent_worker:system_prompt": system_prompt})
+            else:
+                logger.warning(
+                    "No system_prompt found in entailment_evaluation.yaml, CodeActAgent might use a default one.",
+                    extra=log_details,
+                )
+
+        except (FileNotFoundError, ValueError) as e:
+            error_message = f"Failed to load entailment prompt template: {e}"
+            logger.error(error_message, extra=log_details)
+            return None, error_message
+
+        @retry(
+            stop=stop_after_attempt(self.max_retries),
+            wait=wait_exponential(multiplier=1, min=4, max=10),
+        )
+        def _attempt_evaluation_with_prompt(current_user_prompt: str) -> str:
+            """Handle the actual LLM call with retries, ensuring a string response."""
+            # CodeActAgent's `chat` method returns an AgentChatResponse
+            # The actual response string is in response.response
+            logger.debug(
+                f"Calling CodeActAgent with prompt: {current_user_prompt}",
+                extra=log_details,
+            )
+            result = self.agent.chat(current_user_prompt)
+
+            if hasattr(result, "response") and isinstance(result.response, str):
+                # As per on-llm_interaction_strategy.md, agent's final output is via print(json.dumps(...))
+                # The CodeActAgent might directly return the JSON string if prompted correctly,
+                # or it might return the content of the last print statement.
+                # The prompt asks for "Output only the float score."
+                # If the LLM follows this, result.response will be the score string.
+                # If it's a CodeActAgent that *executes* code to print JSON,
+                # we might need to parse `result.sources[-1].raw_output` if it's a tool call that prints.
+                # However, the prompt instructs "Output only the float score", implying direct output.
+                response_str = result.response.strip()
+                logger.info(
+                    f"Raw response from CodeActAgent: '{response_str}'",
+                    extra=log_details,
+                )
+                return response_str
+            else:
+                # Fallback or error if the response structure is not as expected
+                logger.error(
+                    f"LLM did not return expected response structure. Got: {result}",
+                    extra=log_details,
+                )
+                raise ValueError(
+                    f"LLM did not return a string response. Got: {type(result)}"
+                )
+
+        try:
+            logger.info(
+                f"Evaluating entailment for claim_id: {claim_id} with source_id: {source_id}, max_retries: {self.max_retries}",
+                extra=log_details,
+            )
+            response_text = _attempt_evaluation_with_prompt(user_prompt)
+
+            # The prompt asks for "Output only the float score."
+            # So, response_text should be the score itself.
+            try:
+                score = float(response_text)
+                if not (0.0 <= score <= 1.0):
+                    # Score out of range, treat as an invalid response
+                    error_message = (
+                        f"LLM returned an out-of-range score for claim_id {claim_id}. "
+                        f"Score: {score}, Response: '{response_text}'"
+                    )
+                    logger.warning(error_message, extra=log_details)
+                    return None, error_message  # Treat as failure to get valid score
+
+                logger.info(
+                    f"Successfully evaluated entailment for claim_id: {claim_id}. Score: {score}",
+                    extra={**log_details, "entailed_score": score},
+                )
+                return score, "success"
+            except (ValueError, TypeError):
+                # This handles cases where response_text is not a float.
+                # This could be due to the LLM not following instructions, or returning complex JSON.
+                # For now, if it's not a direct float, we treat it as an error for this agent's design.
+                error_message = (
+                    f"LLM returned an invalid score format for claim_id {claim_id}. "
+                    f"Expected a float, got: '{response_text}'"
+                )
+                logger.warning(error_message, extra=log_details)
+                # This is a critical failure in parsing the expected output.
+                return None, error_message
+
+        except Exception as e:
+            final_exception: BaseException = e
+            if isinstance(e, RetryError) and e.__cause__:
+                final_exception = e.__cause__
+
+            error_message = (
+                f"Error during entailment evaluation for claim_id {claim_id} "
+                f"after {self.max_retries} retries. Root cause: {final_exception!r}"
+            )
+            logger.error(error_message, exc_info=True, extra=log_details)
+            return None, error_message

--- a/services/aclarai-core/aclarai_core/dirty_block_consumer.py
+++ b/services/aclarai-core/aclarai_core/dirty_block_consumer.py
@@ -6,15 +6,27 @@ from vault-watcher and updates graph nodes with proper version checking.
 
 import json
 import logging
+
+# Actual LLM provider imports would go into _initialize_llm or a factory
+import os
+import re  # For markdown update
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+from unittest.mock import (
+    MagicMock,
+)  # For fallback non-functional mock in _initialize_llm
 
 from aclarai_shared import load_config
+from aclarai_shared.embedding.storage import VectorStoreManager
 from aclarai_shared.graph.neo4j_manager import Neo4jGraphManager
+from aclarai_shared.import_system import write_file_atomically
 from aclarai_shared.mq import RabbitMQManager
+from aclarai_shared.tools.factory import ToolFactory
 from aclarai_shared.vault import BlockParser
+from llama_index.core.llms.llm import LLM as LlamaLLM
 
+from .agents.entailment_agent import EntailmentAgent
 from .concept_processor import ConceptProcessor
 
 logger = logging.getLogger(__name__)
@@ -33,20 +45,139 @@ class DirtyBlockConsumer:
         self.graph_manager = Neo4jGraphManager(self.config)
         self.block_parser = BlockParser()
         self.concept_processor = ConceptProcessor(self.config)
-        # Initialize RabbitMQ manager
         self.rabbitmq_manager = RabbitMQManager(self.config, "aclarai-core")
         self.queue_name = "aclarai_dirty_blocks"
-        # Vault paths from config
         self.vault_path = Path(self.config.vault_path)
+
+        self.llm = self._initialize_llm()  # self.llm can be Optional[LlamaLLM]
+
+        # Ensure ToolFactory gets a valid LLM or handles None if llm init fails
+        # For now, assuming ToolFactory might not strictly need an LLM for all tool types,
+        # or that the tools for entailment_agent don't need one at factory init time.
+        # If llm is None here and ToolFactory requires it, this could be an issue.
+        # However, EntailmentAgent itself receives self.llm, so if it's None, agent will fail.
+        self.vector_store_manager = VectorStoreManager(
+            self.config
+        )  # ToolFactory needs this
+        tool_factory_config = self.config.dict(
+            exclude_unset=True
+        )  # Pass config as dict
+        self.tool_factory = ToolFactory(tool_factory_config, self.vector_store_manager)
+
+        if self.llm:  # Only initialize agent if LLM loaded successfully
+            self.entailment_agent = EntailmentAgent(
+                self.llm, self.tool_factory, self.config
+            )
+        else:
+            self.entailment_agent = None  # Explicitly set to None if LLM fails
+            logger.error(
+                "EntailmentAgent could not be initialized because LLM failed to load."
+            )
+
         logger.info(
-            "DirtyBlockConsumer: Initialized consumer",
+            "DirtyBlockConsumer: Initialized consumer.",
             extra={
                 "service": "aclarai-core",
                 "filename.function_name": "dirty_block_consumer.__init__",
                 "rabbitmq_host": self.config.rabbitmq_host,
                 "queue_name": self.queue_name,
+                "llm_initialized": self.llm is not None
+                and not isinstance(self.llm, MagicMock),
+                "entailment_agent_initialized": self.entailment_agent is not None,
             },
         )
+
+    def _initialize_llm(self) -> Optional[LlamaLLM]:
+        llm_model_name_entailment = self.config.model.claimify.get("entailment")
+        llm_model_name_default = self.config.model.claimify.get("default")
+
+        llm_model_name = llm_model_name_entailment or llm_model_name_default
+
+        log_details = {
+            "service": "aclarai-core",
+            "filename.function_name": "dirty_block_consumer._initialize_llm",
+            "configured_entailment_llm": llm_model_name_entailment,
+            "configured_default_llm": llm_model_name_default,
+            "effective_llm_model_name": llm_model_name,
+        }
+
+        if not llm_model_name:
+            logger.error(
+                "No LLM model configured for claimify entailment or default in dirty_block_consumer.",
+                extra=log_details,
+            )
+            return None
+
+        logger.info(
+            f"Attempting to initialize LLM for evaluation agents with model: {llm_model_name}",
+            extra=log_details,
+        )
+
+        try:
+            if "gpt" in llm_model_name.lower():
+                from llama_index.llms.openai import OpenAI
+
+                api_key = os.getenv("OPENAI_API_KEY")
+                if not api_key:
+                    logger.error(
+                        f"OPENAI_API_KEY not set. Cannot initialize OpenAI model '{llm_model_name}'. Returning non-functional mock.",
+                        extra=log_details,
+                    )
+                    return MagicMock(
+                        spec=LlamaLLM, name=f"UninitializedOpenAI_{llm_model_name}"
+                    )
+
+                temperature_str = self.config.processing.get("temperature", "0.1")
+                max_tokens_str = self.config.processing.get("max_tokens", "1000")
+
+                try:
+                    temperature = float(temperature_str)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"Invalid temperature value '{temperature_str}', using default 0.1",
+                        extra=log_details,
+                    )
+                    temperature = 0.1
+
+                try:
+                    max_tokens = int(max_tokens_str)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"Invalid max_tokens value '{max_tokens_str}', using default 1000",
+                        extra=log_details,
+                    )
+                    max_tokens = 1000
+
+                return OpenAI(
+                    model=llm_model_name,
+                    api_key=api_key,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            else:
+                logger.error(
+                    f"Unsupported or unknown LLM model configured: {llm_model_name}. Cannot initialize. Returning non-functional mock.",
+                    extra=log_details,
+                )
+                return MagicMock(
+                    spec=LlamaLLM, name=f"UninitializedUnknownModel_{llm_model_name}"
+                )
+
+        except ImportError as ie:
+            logger.error(
+                f"Failed to import LLM library for model {llm_model_name}: {ie}. Please ensure necessary packages are installed. Returning non-functional mock.",
+                extra=log_details,
+            )
+            return MagicMock(spec=LlamaLLM, name=f"ImportError_{llm_model_name}")
+        except Exception as e:
+            logger.error(
+                f"Failed to initialize LLM model {llm_model_name}: {e}. Returning non-functional mock.",
+                exc_info=True,
+                extra=log_details,
+            )
+            return MagicMock(
+                spec=LlamaLLM, name=f"InitializationError_{llm_model_name}"
+            )
 
     def connect(self):
         """Establish connection to RabbitMQ."""
@@ -61,14 +192,12 @@ class DirtyBlockConsumer:
         """Start consuming messages from the dirty blocks queue."""
         if not self.rabbitmq_manager.is_connected():
             self.connect()
-        # Get channel from manager
         channel = self.rabbitmq_manager.get_channel()
-        # Set up message consumer
-        channel.basic_qos(prefetch_count=1)  # Process one message at a time
+        channel.basic_qos(prefetch_count=1)
         channel.basic_consume(
             queue=self.queue_name,
             on_message_callback=self._on_message_received,
-            auto_ack=False,  # Manual acknowledgment for reliability
+            auto_ack=False,
         )
         logger.info(
             "DirtyBlockConsumer: Starting to consume messages",
@@ -82,218 +211,201 @@ class DirtyBlockConsumer:
             while self.rabbitmq_manager.is_connected():
                 self.rabbitmq_manager.process_data_events(time_limit=1)
         except KeyboardInterrupt:
-            logger.info(
-                "DirtyBlockConsumer: Stopping consumption due to interrupt",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer.start_consuming",
-                },
-            )
-            channel.close()
+            logger.info("DirtyBlockConsumer: Stopping consumption due to interrupt")
+            if channel and channel.is_open:  # Check if channel is valid before closing
+                channel.close()
             self.disconnect()
 
     def _on_message_received(
         self, channel: Any, method: Any, _properties: Any, body: bytes
     ):
-        """
-        Process a received dirty block message.
-        Args:
-            channel: RabbitMQ channel
-            method: Message delivery method
-            properties: Message properties
-            body: Message body (JSON)
-        """
+        message_data_for_log = {"aclarai_id": "unknown", "change_type": "unknown"}
         try:
-            # Parse message
             message = json.loads(body.decode("utf-8"))
+            message_data_for_log["aclarai_id"] = message.get("aclarai_id", "unknown")
+            message_data_for_log["change_type"] = message.get("change_type", "unknown")
+            message_data_for_log["file_path"] = message.get("file_path", "unknown")
+
             logger.debug(
                 "DirtyBlockConsumer: Received dirty block message",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._on_message_received",
-                    "aclarai_id": message.get("aclarai_id"),
-                    "change_type": message.get("change_type"),
-                    "file_path": message.get("file_path"),
-                },
+                extra=message_data_for_log,
             )
-            # Process the dirty block
             success = self._process_dirty_block(message)
             if success:
-                # Acknowledge message
                 channel.basic_ack(delivery_tag=method.delivery_tag)
                 logger.debug(
                     "DirtyBlockConsumer: Successfully processed and acknowledged message",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._on_message_received",
-                        "aclarai_id": message.get("aclarai_id"),
-                    },
+                    extra=message_data_for_log,
                 )
             else:
-                # Reject message and requeue for retry
                 channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
                 logger.warning(
                     "DirtyBlockConsumer: Failed to process message, requeuing",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._on_message_received",
-                        "aclarai_id": message.get("aclarai_id"),
-                    },
+                    extra=message_data_for_log,
                 )
         except json.JSONDecodeError as e:
             logger.error(
                 f"DirtyBlockConsumer: Invalid JSON in message: {e}",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._on_message_received",
-                    "error": str(e),
-                },
+                extra={"body_preview": body[:200]},
             )
-            # Acknowledge bad message to remove it from queue
             channel.basic_ack(delivery_tag=method.delivery_tag)
         except Exception as e:
             logger.error(
                 f"DirtyBlockConsumer: Error processing message: {e}",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._on_message_received",
-                    "error": str(e),
-                },
+                exc_info=True,
+                extra=message_data_for_log,
             )
-            # Reject and requeue for retry
             channel.basic_nack(delivery_tag=method.delivery_tag, requeue=True)
 
     def _process_dirty_block(self, message: Dict[str, Any]) -> bool:
-        """
-        Process a single dirty block message.
-        Args:
-            message: The dirty block message from RabbitMQ
-        Returns:
-            True if processing was successful, False otherwise
-        """
+        aclarai_id_from_message = message.get("aclarai_id")
         try:
             aclarai_id = message["aclarai_id"]
-            file_path = Path(message["file_path"])
+            file_path_str = message["file_path"]
             change_type = message["change_type"]
-            # Skip deleted blocks for now (could be handled in future)
+            file_path = Path(file_path_str)
+
             if change_type == "deleted":
                 logger.info(
-                    "DirtyBlockConsumer: Skipping deleted block",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._process_dirty_block",
-                        "aclarai_id": aclarai_id,
-                        "change_type": change_type,
-                    },
+                    f"Skipping deleted block: {aclarai_id}",
+                    extra={"aclarai_id": aclarai_id},
                 )
                 return True
-            # Read and parse the current block from the file
+
             current_block = self._read_block_from_file(file_path, aclarai_id)
             if current_block is None:
                 logger.warning(
-                    "DirtyBlockConsumer: Could not read block from file",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._process_dirty_block",
-                        "aclarai_id": aclarai_id,
-                        "file_path": str(file_path),
-                    },
+                    f"Could not read block {aclarai_id} from file {file_path}",
+                    extra={"aclarai_id": aclarai_id, "file_path": str(file_path)},
                 )
                 return False
-            # Sync block with graph using proper version checking
+
             sync_success = self._sync_block_with_graph(current_block, file_path)
-            # If sync was successful and this is a new or updated block, process for concepts
+            if not sync_success:
+                logger.warning(
+                    f"Failed to sync block {aclarai_id} with graph.",
+                    extra={"aclarai_id": aclarai_id},
+                )
+                return False
+
+            if sync_success and change_type in ("created", "modified"):
+                if not self.entailment_agent:
+                    logger.error(
+                        f"EntailmentAgent not initialized, skipping evaluation for block {aclarai_id}.",
+                        extra={"aclarai_id": aclarai_id},
+                    )
+                else:
+                    logger.info(
+                        f"Processing block {aclarai_id} for claim evaluation.",
+                        extra={"aclarai_id": aclarai_id},
+                    )
+                    source_text = current_block["semantic_text"]
+                    source_id = current_block["aclarai_id"]
+                    absolute_file_path = (
+                        self.vault_path / file_path
+                        if not file_path.is_absolute()
+                        else file_path
+                    )
+                    source_filepath_str = str(absolute_file_path)
+                    claims_to_evaluate = self._get_claims_for_evaluation(source_id)
+
+                    for claim_data in claims_to_evaluate:
+                        claim_id = claim_data["id"]
+                        claim_text = claim_data["text"]
+                        logger.info(
+                            f"Evaluating claim {claim_id} from source {source_id}",
+                            extra={
+                                "aclarai_id_claim": claim_id,
+                                "aclarai_id_source": source_id,
+                            },
+                        )
+                        entailment_score, err_msg_ent = (
+                            self.entailment_agent.evaluate_entailment(
+                                claim_id=claim_id,
+                                claim_text=claim_text,
+                                source_id=source_id,
+                                source_text=source_text,
+                            )
+                        )
+                        if err_msg_ent != "success":
+                            logger.warning(
+                                f"Entailment evaluation failed for claim {claim_id}: {err_msg_ent}",
+                                extra={
+                                    "aclarai_id_claim": claim_id,
+                                    "error": err_msg_ent,
+                                },
+                            )
+
+                        logger.info(
+                            f"Claim {claim_id} entailment_score: {entailment_score}",
+                            extra={
+                                "aclarai_id_claim": claim_id,
+                                "entailed_score": entailment_score,
+                            },
+                        )
+                        if entailment_score is not None:
+                            self._update_entailment_score_in_neo4j(
+                                claim_id, source_id, entailment_score
+                            )
+                            self._update_markdown_with_entailment_score(
+                                source_filepath_str, source_id, entailment_score
+                            )
+                        else:
+                            self._update_entailment_score_in_neo4j(
+                                claim_id, source_id, None
+                            )
+
             if sync_success and change_type in ("created", "modified"):
                 try:
                     concept_result = self.concept_processor.process_block_for_concepts(
-                        current_block,
-                        block_type="claim",  # Assume claim type for now
+                        current_block, block_type="claim"
                     )
                     logger.debug(
-                        f"Concept processing completed for block {aclarai_id}: "
-                        f"{concept_result.get('merged_count', 0)} merged, "
-                        f"{concept_result.get('promoted_count', 0)} promoted",
-                        extra={
-                            "service": "aclarai-core",
-                            "filename.function_name": "dirty_block_consumer._process_dirty_block",
-                            "aclarai_id": aclarai_id,
-                            "concept_processing_success": concept_result.get(
-                                "success", False
-                            ),
-                        },
+                        f"Concept processing for block {aclarai_id} result: {concept_result.get('merged_count', 0)} merged, {concept_result.get('promoted_count', 0)} promoted.",
+                        extra={"aclarai_id": aclarai_id},
                     )
                 except Exception as e:
-                    # Don't fail the whole message if concept processing fails
                     logger.warning(
-                        f"Concept processing failed for block {aclarai_id}: {e}",
-                        extra={
-                            "service": "aclarai-core",
-                            "filename.function_name": "dirty_block_consumer._process_dirty_block",
-                            "aclarai_id": aclarai_id,
-                            "concept_processing_error": str(e),
-                        },
+                        f"Concept processing (original call) failed for block {aclarai_id}: {e}",
+                        extra={"aclarai_id": aclarai_id, "error": str(e)},
                     )
+
             return sync_success
         except KeyError as e:
             logger.error(
-                f"DirtyBlockConsumer: Missing required field in message: {e}",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._process_dirty_block",
-                    "error": str(e),
-                },
+                f"DirtyBlockConsumer: Missing required field in message: {e}. Message body: {message}",
+                extra={"error": f"KeyError: {str(e)}"},
             )
             return False
         except Exception as e:
             logger.error(
-                f"DirtyBlockConsumer: Error processing dirty block: {e}",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._process_dirty_block",
-                    "aclarai_id": message.get("aclarai_id"),
-                    "error": str(e),
-                },
+                f"DirtyBlockConsumer: Error processing dirty block for aclarai_id '{aclarai_id_from_message}': {e}",
+                exc_info=True,
+                extra={"aclarai_id": aclarai_id_from_message, "error": str(e)},
             )
             return False
 
     def _read_block_from_file(
         self, file_path: Path, aclarai_id: str
     ) -> Optional[Dict[str, Any]]:
-        """
-        Read and parse a specific block from a Markdown file.
-        Args:
-            file_path: Path to the Markdown file
-            aclarai_id: The aclarai:id to look for
-        Returns:
-            Block dictionary with aclarai_id, version, semantic_text, and content_hash
-        """
         try:
-            # Make file_path absolute if relative to vault
             if not file_path.is_absolute():
                 file_path = self.vault_path / file_path
             if not file_path.exists():
                 logger.warning(
-                    "DirtyBlockConsumer: File does not exist",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._read_block_from_file",
-                        "file_path": str(file_path),
-                        "aclarai_id": aclarai_id,
-                    },
+                    f"File does not exist: {file_path}",
+                    extra={"file_path": str(file_path), "aclarai_id": aclarai_id},
                 )
                 return None
-            # Read file content
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            # Extract the specific block
             block = self.block_parser.find_block_by_id(content, aclarai_id)
             return block
         except Exception as e:
             logger.error(
-                f"DirtyBlockConsumer: Error reading block from file: {e}",
+                f"Error reading block from file: {file_path}, id: {aclarai_id}: {e}",
+                exc_info=True,
                 extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._read_block_from_file",
                     "file_path": str(file_path),
                     "aclarai_id": aclarai_id,
                     "error": str(e),
@@ -302,93 +414,51 @@ class DirtyBlockConsumer:
             return None
 
     def _sync_block_with_graph(self, block: Dict[str, Any], file_path: Path) -> bool:
-        """
-        Synchronize a block with the Neo4j graph using proper version checking.
-        Implements the optimistic locking strategy from sprint_4-Block_syncing_loop.md:
-        - Compare vault_ver with graph_ver
-        - If vault_ver == graph_ver: Clean update, increment version
-        - If vault_ver > graph_ver: Proceed with update (vault is more recent)
-        - If vault_ver < graph_ver: Conflict detected, skip update and log
-        Args:
-            block: Block dictionary with aclarai_id, version, semantic_text, content_hash
-            file_path: Path to the source file
-        Returns:
-            True if sync was successful, False otherwise
-        """
         try:
             aclarai_id = block["aclarai_id"]
             vault_version = block["version"]
-            # Get existing block from graph
             existing_block = self._get_block_from_graph(aclarai_id)
             if existing_block is None:
-                # New block - create in graph
                 self._create_block_in_graph(block, file_path)
                 logger.info(
-                    "DirtyBlockConsumer: Created new block in graph",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._sync_block_with_graph",
-                        "aclarai_id": aclarai_id,
-                        "file": str(file_path),
-                        "action": "create",
-                    },
+                    "Created new block in graph",
+                    extra={"aclarai_id": aclarai_id, "file": str(file_path)},
                 )
                 return True
-            # Existing block - perform version checking
+
             graph_version = existing_block.get("version", 1)
             existing_hash = existing_block.get("hash", "")
             new_hash = block["content_hash"]
-            # Check if content actually changed
+
             if existing_hash == new_hash:
                 logger.debug(
-                    "DirtyBlockConsumer: Block content unchanged, skipping",
-                    extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._sync_block_with_graph",
-                        "aclarai_id": aclarai_id,
-                        "action": "unchanged",
-                    },
+                    "Block content unchanged, skipping graph update",
+                    extra={"aclarai_id": aclarai_id},
                 )
                 return True
-            # Implement version checking logic
+
             if vault_version < graph_version:
-                # Conflict detected - vault is stale
                 logger.warning(
-                    "DirtyBlockConsumer: Version conflict detected - vault is stale",
+                    "Version conflict: vault is stale. Skipping update.",
                     extra={
-                        "service": "aclarai-core",
-                        "filename.function_name": "dirty_block_consumer._sync_block_with_graph",
                         "aclarai_id": aclarai_id,
                         "vault_version": vault_version,
                         "graph_version": graph_version,
-                        "action": "skip_conflict",
-                        "file": str(file_path),
                     },
                 )
-                return True  # Skip update but don't fail the message
-            # Proceed with update (vault_ver >= graph_ver)
+                return True
+
             self._update_block_in_graph(block, existing_block, file_path)
             logger.info(
-                "DirtyBlockConsumer: Updated block in graph",
-                extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._sync_block_with_graph",
-                    "aclarai_id": aclarai_id,
-                    "file": str(file_path),
-                    "action": "update",
-                    "vault_version": vault_version,
-                    "graph_version": graph_version,
-                    "old_hash": existing_hash[:8],
-                    "new_hash": new_hash[:8],
-                },
+                "Updated block in graph",
+                extra={"aclarai_id": aclarai_id, "file": str(file_path)},
             )
             return True
         except Exception as e:
             logger.error(
-                f"DirtyBlockConsumer: Error syncing block with graph: {e}",
+                f"Error syncing block with graph: {block.get('aclarai_id')}: {e}",
+                exc_info=True,
                 extra={
-                    "service": "aclarai-core",
-                    "filename.function_name": "dirty_block_consumer._sync_block_with_graph",
                     "aclarai_id": block.get("aclarai_id"),
                     "file": str(file_path),
                     "error": str(e),
@@ -397,7 +467,6 @@ class DirtyBlockConsumer:
             return False
 
     def _get_block_from_graph(self, aclarai_id: str) -> Optional[Dict[str, Any]]:
-        """Get block properties from Neo4j graph by aclarai_id."""
         cypher_query = """
         MATCH (b:Block {id: $aclarai_id})
         RETURN b.id as id, b.text as text, b.hash as hash,
@@ -405,75 +474,206 @@ class DirtyBlockConsumer:
                b.needs_reprocessing as needs_reprocessing
         """
 
-        def _execute_get_block() -> Optional[Dict[str, Any]]:
+        def _execute() -> Optional[Dict[str, Any]]:
             with self.graph_manager.session() as session:
                 result = session.run(cypher_query, aclarai_id=aclarai_id)
                 record = result.single()
                 return dict(record) if record else None
 
-        return self.graph_manager._retry_with_backoff(_execute_get_block)
+        return self.graph_manager._retry_with_backoff(_execute)
 
     def _create_block_in_graph(self, block: Dict[str, Any], file_path: Path):
-        """Create a new block in the Neo4j graph."""
         current_time = datetime.now(timezone.utc).isoformat()
         cypher_query = """
         MERGE (b:Block {id: $aclarai_id})
         ON CREATE SET
-            b.text = $text,
-            b.hash = $hash,
-            b.version = $version,
+            b.text = $text, b.hash = $hash, b.version = $version,
             b.last_updated = datetime($last_updated),
-            b.needs_reprocessing = true,
-            b.source_file = $source_file
+            b.needs_reprocessing = true, b.source_file = $source_file
         """
+        params = {
+            "aclarai_id": block["aclarai_id"],
+            "text": block["semantic_text"],
+            "hash": block["content_hash"],
+            "version": block["version"],
+            "last_updated": current_time,
+            "source_file": str(file_path),
+        }
 
-        def _execute_create_block():
+        def _execute():
             with self.graph_manager.session() as session:
-                session.run(
-                    cypher_query,
-                    aclarai_id=block["aclarai_id"],
-                    text=block["semantic_text"],
-                    hash=block["content_hash"],
-                    version=block["version"],
-                    last_updated=current_time,
-                    source_file=str(file_path),
-                )
+                session.run(cypher_query, **params)
 
-        self.graph_manager._retry_with_backoff(_execute_create_block)
+        self.graph_manager._retry_with_backoff(_execute)
 
     def _update_block_in_graph(
         self, block: Dict[str, Any], existing_block: Dict[str, Any], file_path: Path
     ):
-        """
-        Update an existing block in the Neo4j graph.
-        This implements the proper version incrementing as specified:
-        - Increment the graph version (ver = ver + 1)
-        - Mark with needs_reprocessing: true
-        """
         current_time = datetime.now(timezone.utc).isoformat()
-        # Increment the graph version, not use the vault version
         current_graph_version = existing_block.get("version", 1)
         new_version = current_graph_version + 1
         cypher_query = """
         MATCH (b:Block {id: $aclarai_id})
-        SET b.text = $text,
-            b.hash = $hash,
-            b.version = $version,
+        SET b.text = $text, b.hash = $hash, b.version = $version,
             b.last_updated = datetime($last_updated),
-            b.needs_reprocessing = true,
-            b.source_file = $source_file
+            b.needs_reprocessing = true, b.source_file = $source_file
         """
+        params = {
+            "aclarai_id": block["aclarai_id"],
+            "text": block["semantic_text"],
+            "hash": block["content_hash"],
+            "version": new_version,
+            "last_updated": current_time,
+            "source_file": str(file_path),
+        }
 
-        def _execute_update_block():
+        def _execute():
             with self.graph_manager.session() as session:
-                session.run(
-                    cypher_query,
-                    aclarai_id=block["aclarai_id"],
-                    text=block["semantic_text"],
-                    hash=block["content_hash"],
-                    version=new_version,
-                    last_updated=current_time,
-                    source_file=str(file_path),
-                )
+                session.run(cypher_query, **params)
 
-        self.graph_manager._retry_with_backoff(_execute_update_block)
+        self.graph_manager._retry_with_backoff(_execute)
+
+    def _get_claims_for_evaluation(self, source_block_id: str) -> List[Dict[str, Any]]:
+        query = """
+        MATCH (claim:Claim)-[r:ORIGINATES_FROM]->(block:Block {id: $source_block_id})
+        WHERE r.entailed_score IS NULL OR claim.needs_reprocessing = true
+        RETURN claim.id AS id, claim.text AS text
+        """
+        params = {"source_block_id": source_block_id}
+        try:
+            results = self.graph_manager.execute_query(query, parameters=params)
+            logger.info(
+                f"Found {len(results)} claims from block {source_block_id} for entailment evaluation."
+            )
+            return results
+        except Exception as e:
+            logger.error(
+                f"Failed to fetch claims for evaluation from block {source_block_id}: {e}",
+                exc_info=True,
+                extra={"source_block_id": source_block_id, "error": str(e)},
+            )
+            return []
+
+    def _update_entailment_score_in_neo4j(
+        self, claim_id: str, source_id: str, score: Optional[float]
+    ):
+        log_details = {
+            "claim_id": claim_id,
+            "source_id": source_id,
+            "entailed_score": score,
+        }
+        logger.info("Attempting to update Neo4j entailment score.", extra=log_details)
+        query = """
+        MATCH (claim:Claim {id: $claim_id})-[rel:ORIGINATES_FROM]->(block:Block {id: $source_id})
+        SET rel.entailed_score = $entailed_score
+        RETURN claim.id AS claimId, rel.entailed_score AS updatedScore
+        """
+        params = {"claim_id": claim_id, "source_id": source_id, "entailed_score": score}
+        try:
+            results = self.graph_manager.execute_query(query, parameters=params)
+            if results and len(results) > 0:
+                logger.info(
+                    f"Successfully updated Neo4j entailment score to {results[0].get('updatedScore')}.",
+                    extra=log_details,
+                )
+            else:
+                logger.warning(
+                    "Neo4j update for entailment score did not return results. Relationship or nodes might be missing.",
+                    extra=log_details,
+                )
+        except Exception as e:
+            logger.error(
+                f"Failed to update entailment score in Neo4j: {e}",
+                exc_info=True,
+                extra=log_details,
+            )
+
+    def _update_markdown_with_entailment_score(
+        self, source_filepath: str, source_block_id: str, score: float
+    ):
+        log_details = {
+            "source_block_id": source_block_id,
+            "entailed_score": score,
+            "filepath": source_filepath,
+        }
+        logger.info(
+            "Attempting to update Markdown with entailment score.", extra=log_details
+        )
+        try:
+            markdown_path = Path(source_filepath)
+            if not markdown_path.exists():
+                logger.error(
+                    f"Markdown file not found: {source_filepath}", extra=log_details
+                )
+                return
+
+            content = markdown_path.read_text(encoding="utf-8")
+            original_content = content
+
+            block_id_pattern_str = rf"(<!--\s*aclarai:id={re.escape(source_block_id)}(?:[^\S\n]+[^<>]*?)?\s+ver=)(\d+)(\s*[^<>]*?-->)"
+            block_id_match = re.search(block_id_pattern_str, content)
+
+            if not block_id_match:
+                logger.warning(
+                    f"Could not find aclarai:id comment for block {source_block_id} in {source_filepath}.",
+                    extra=log_details,
+                )
+                return
+
+            main_id_comment_full = block_id_match.group(0)
+            pre_ver_part, current_version_str, post_ver_part = block_id_match.groups()
+            current_version = int(current_version_str)
+            new_version = current_version + 1
+            updated_main_id_comment = f"{pre_ver_part}{new_version}{post_ver_part}"
+            content_after_ver_update = content.replace(
+                main_id_comment_full, updated_main_id_comment, 1
+            )
+
+            score_comment_str = f"<!-- aclarai:entailed_score={score:.2f} -->"
+            lines = content_after_ver_update.splitlines()
+            main_id_comment_line_index = -1
+            for i, line in enumerate(lines):
+                if updated_main_id_comment.splitlines()[0] in line:
+                    main_id_comment_line_index = i
+                    break
+
+            if main_id_comment_line_index == -1:
+                logger.error(
+                    "Could not re-locate main ID comment line after version increment.",
+                    extra=log_details,
+                )
+                return
+
+            existing_score_pattern = re.compile(
+                r"^\s*<!--\s*aclarai:entailed_score=[\d.]+\s*-->\s*$"
+            )
+            score_insertion_point_index = main_id_comment_line_index + 1
+            found_and_updated_existing_score = False
+
+            if score_insertion_point_index < len(
+                lines
+            ) and existing_score_pattern.match(lines[score_insertion_point_index]):
+                lines[score_insertion_point_index] = score_comment_str
+                found_and_updated_existing_score = True
+
+            if not found_and_updated_existing_score:
+                lines.insert(score_insertion_point_index, score_comment_str)
+
+            updated_content = "\n".join(lines)
+            if updated_content != original_content:
+                write_file_atomically(markdown_path, updated_content)
+                logger.info(
+                    f"Successfully updated Markdown with score and new version {new_version}.",
+                    extra=log_details,
+                )
+            else:
+                logger.info(
+                    "Markdown content did not change. Score/version might be identical.",
+                    extra=log_details,
+                )
+        except Exception as e:
+            logger.error(
+                f"Failed to update Markdown for entailment score: {e}",
+                exc_info=True,
+                extra=log_details,
+            )

--- a/services/aclarai-core/tests/agents/__init__.py
+++ b/services/aclarai-core/tests/agents/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory 'agents' as a package.

--- a/services/aclarai-core/tests/agents/test_entailment_agent.py
+++ b/services/aclarai-core/tests/agents/test_entailment_agent.py
@@ -1,0 +1,226 @@
+from unittest.mock import MagicMock, patch  # Added call for retry check
+
+import pytest
+from aclarai_core.agents.entailment_agent import EntailmentAgent  # Corrected
+from aclarai_shared.config import aclaraiConfig
+from aclarai_shared.tools.factory import ToolFactory
+from llama_index.core.base.response.schema import Response as LlamaResponse
+from llama_index.core.llms.llm import LLM as LlamaLLM
+
+
+# Minimal config for testing
+@pytest.fixture
+def mock_config():
+    config = MagicMock(spec=aclaraiConfig)
+    config.processing = MagicMock()
+    config.processing.retries = {"max_attempts": 3}
+    return config
+
+
+@pytest.fixture
+def mock_llm():
+    return MagicMock(spec=LlamaLLM)
+
+
+@pytest.fixture
+def mock_tool_factory():
+    factory = MagicMock(spec=ToolFactory)
+    factory.get_tools_for_agent.return_value = []
+    return factory
+
+
+@pytest.fixture
+def entailment_agent_instance(mock_llm, mock_tool_factory, mock_config):
+    with patch(
+        "aclarai_core.agents.entailment_agent.CodeActAgent"
+    ) as MockCodeActAgent:  # Corrected
+        mock_agent_internal_instance = MockCodeActAgent.from_tools.return_value
+        agent_under_test = EntailmentAgent(
+            llm=mock_llm, tool_factory=mock_tool_factory, config=mock_config
+        )
+        agent_under_test.agent = mock_agent_internal_instance
+        return agent_under_test
+
+
+class TestEntailmentAgent:
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_evaluate_entailment_success(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.return_value = {
+            "template": "user_prompt",
+            "system_prompt": "system_prompt",
+        }
+        mock_chat_response = MagicMock(spec=LlamaResponse)
+        mock_chat_response.response = "0.85"
+        entailment_agent_instance.agent.chat.return_value = mock_chat_response
+
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score == 0.85
+        assert msg == "success"
+        entailment_agent_instance.agent.chat.assert_called_once_with("user_prompt")
+        entailment_agent_instance.agent.update_prompts.assert_called_once_with(
+            {"agent_worker:system_prompt": "system_prompt"}
+        )
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_evaluate_entailment_llm_error_with_retries(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.return_value = {"template": "user_prompt"}
+        entailment_agent_instance.agent.chat.side_effect = ValueError("LLM API error")
+
+        max_retries = entailment_agent_instance.max_retries
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score is None
+        assert "LLM API error" in msg
+        assert f"after {max_retries} retries" in msg
+        assert entailment_agent_instance.agent.chat.call_count == max_retries
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_evaluate_entailment_invalid_score_format(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.return_value = {"template": "user_prompt"}
+        mock_chat_response = MagicMock(spec=LlamaResponse)
+        mock_chat_response.response = "not a float"
+        entailment_agent_instance.agent.chat.return_value = mock_chat_response
+
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score is None
+        assert "invalid score format" in msg
+        assert "Expected a float, got: 'not a float'" in msg
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_evaluate_entailment_score_out_of_range_high(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.return_value = {"template": "user_prompt"}
+        mock_chat_response = MagicMock(spec=LlamaResponse)
+        mock_chat_response.response = "1.5"
+        entailment_agent_instance.agent.chat.return_value = mock_chat_response
+
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score is None
+        assert "out-of-range score" in msg
+        assert "Score: 1.5" in msg
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_evaluate_entailment_score_out_of_range_low(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.return_value = {"template": "user_prompt"}
+        mock_chat_response = MagicMock(spec=LlamaResponse)
+        mock_chat_response.response = "-0.5"
+        entailment_agent_instance.agent.chat.return_value = mock_chat_response
+
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score is None
+        assert "out-of-range score" in msg
+        assert "Score: -0.5" in msg
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_evaluate_entailment_prompt_load_failure(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.side_effect = FileNotFoundError("Prompt file missing")
+
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score is None
+        assert "Failed to load entailment prompt template" in msg
+        assert "Prompt file missing" in msg
+        entailment_agent_instance.agent.chat.assert_not_called()
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    @patch("aclarai_core.agents.entailment_agent.logger")  # Corrected
+    def test_system_prompt_update_logic(
+        self, mock_logger, mock_load_prompt, entailment_agent_instance
+    ):
+        # Case 1: System prompt is present
+        mock_load_prompt.return_value = {
+            "template": "user_prompt_content",
+            "system_prompt": "custom_system_prompt",
+        }
+        mock_chat_response = MagicMock(spec=LlamaResponse)
+        mock_chat_response.response = "0.7"
+        entailment_agent_instance.agent.chat.return_value = mock_chat_response
+
+        entailment_agent_instance.evaluate_entailment("c1", "ct", "s1", "st")
+        entailment_agent_instance.agent.update_prompts.assert_called_with(
+            {"agent_worker:system_prompt": "custom_system_prompt"}
+        )
+        mock_logger.warning.assert_not_called()
+
+        entailment_agent_instance.agent.update_prompts.reset_mock()
+        entailment_agent_instance.agent.chat.reset_mock()
+        mock_load_prompt.reset_mock()
+        mock_logger.reset_mock()
+
+        # Case 2: System prompt is not present (is None)
+        mock_load_prompt.return_value = {
+            "template": "user_prompt_content_2",
+            "system_prompt": None,
+        }
+        mock_chat_response_2 = MagicMock(spec=LlamaResponse)
+        mock_chat_response_2.response = "0.6"
+        entailment_agent_instance.agent.chat.return_value = mock_chat_response_2
+
+        entailment_agent_instance.evaluate_entailment("c2", "ct2", "s2", "st2")
+
+        called_update_prompts_for_system = False
+        for call_args in entailment_agent_instance.agent.update_prompts.call_args_list:
+            if "agent_worker:system_prompt" in call_args[0][0]:
+                called_update_prompts_for_system = True
+                break
+        assert not called_update_prompts_for_system
+
+        mock_logger.warning.assert_called_once()
+        assert "No system_prompt found" in mock_logger.warning.call_args[0][0]
+        entailment_agent_instance.agent.chat.assert_called_once_with(
+            "user_prompt_content_2"
+        )
+
+    @patch("aclarai_core.agents.entailment_agent.load_prompt_template")  # Corrected
+    def test_malformed_prompt_template_data(
+        self, mock_load_prompt, entailment_agent_instance
+    ):
+        mock_load_prompt.return_value = "just a string"
+
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+
+        assert score is None
+        assert "Failed to load entailment prompt template" in msg
+        assert "not a dictionary or is missing 'template' key" in msg
+        entailment_agent_instance.agent.chat.assert_not_called()
+
+        mock_load_prompt.reset_mock()
+        entailment_agent_instance.agent.chat.reset_mock()
+
+        mock_load_prompt.return_value = {"user_facing_prompt": "user_prompt"}
+        score, msg = entailment_agent_instance.evaluate_entailment(
+            "claim1", "claim_text", "src1", "src_text"
+        )
+        assert score is None
+        assert "Failed to load entailment prompt template" in msg
+        assert "not a dictionary or is missing 'template' key" in msg
+        entailment_agent_instance.agent.chat.assert_not_called()

--- a/services/aclarai-core/tests/consumers/__init__.py
+++ b/services/aclarai-core/tests/consumers/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory 'consumers' as a package.

--- a/services/aclarai-core/tests/consumers/test_dirty_block_consumer_evaluations.py
+++ b/services/aclarai-core/tests/consumers/test_dirty_block_consumer_evaluations.py
@@ -1,0 +1,461 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aclarai_core.dirty_block_consumer import DirtyBlockConsumer  # Corrected
+from aclarai_shared.config import aclaraiConfig
+from aclarai_shared.graph.neo4j_manager import Neo4jGraphManager
+from aclarai_shared.tools.factory import ToolFactory
+from llama_index.core.llms.llm import LLM as LlamaLLM
+
+
+@pytest.fixture
+def mock_consumer_config():
+    config = MagicMock(spec=aclaraiConfig)
+    config.vault_path = "/fake/vault"
+    config.rabbitmq_host = "fake_host"
+    config.dict.return_value = {}
+
+    config.processing = MagicMock()
+    config.processing.retries = {"max_attempts": 3}
+
+    config.model = MagicMock()
+    config.model.claimify = {"entailment": "mock_llm", "default": "mock_llm"}
+
+    config.neo4j = MagicMock()
+    config.neo4j.host = "neo4j_mock_host"
+    config.neo4j.port = 7687
+    config.neo4j.user = "user"
+    config.neo4j.password = "pass"
+    config.neo4j.get_neo4j_bolt_url.return_value = "bolt://neo4j_mock_host:7687"
+
+    config.embedding = MagicMock()
+    config.embedding.pgvector = {"collection_name": "utterances", "embed_dim": 384}
+    config.embedding.models = {"default": "mock_model"}
+    config.embedding.device = "cpu"
+    config.embedding.batch_size = 1
+    config.embedding.chunking = {}
+    config.paths = MagicMock()
+
+    return config
+
+
+@pytest.fixture
+def mock_graph_manager_fixture():
+    return MagicMock(spec=Neo4jGraphManager)
+
+
+@pytest.fixture
+def mock_llm_fixture():
+    return MagicMock(spec=LlamaLLM)
+
+
+@pytest.fixture
+def mock_tool_factory_fixture():
+    return MagicMock(spec=ToolFactory)
+
+
+@pytest.fixture
+@patch("aclarai_core.dirty_block_consumer.RabbitMQManager")  # Corrected
+@patch("aclarai_core.dirty_block_consumer.BlockParser")  # Corrected
+@patch("aclarai_core.dirty_block_consumer.ConceptProcessor")  # Corrected
+@patch("aclarai_core.dirty_block_consumer.EntailmentAgent")  # Corrected
+@patch("aclarai_core.dirty_block_consumer.VectorStoreManager")  # Corrected
+def consumer_instance(
+    MockVectorStoreManager,
+    MockEntailmentAgent,
+    MockConceptProcessor,
+    MockBlockParser,
+    MockRabbitMQManager,
+    mock_consumer_config,
+    mock_graph_manager_fixture,
+    mock_llm_fixture,
+    mock_tool_factory_fixture,
+):
+    with patch.object(
+        DirtyBlockConsumer, "_initialize_llm", return_value=mock_llm_fixture
+    ):
+        consumer = DirtyBlockConsumer(config=mock_consumer_config)
+        consumer.graph_manager = mock_graph_manager_fixture
+        consumer.entailment_agent = MockEntailmentAgent()
+        consumer.rabbitmq_manager = MockRabbitMQManager()
+        consumer.block_parser = MockBlockParser()
+        consumer.concept_processor = MockConceptProcessor()
+        consumer.vector_store_manager = MockVectorStoreManager()
+        consumer.tool_factory = mock_tool_factory_fixture
+        return consumer
+
+
+class TestDirtyBlockConsumerEvaluationMethods:
+    def test_update_neo4j_success_with_score(
+        self, consumer_instance, mock_graph_manager_fixture
+    ):
+        claim_id, source_id, score = "c1", "s1", 0.95
+        mock_graph_manager_fixture.execute_query.return_value = [
+            {"updatedScore": score}
+        ]
+
+        consumer_instance._update_entailment_score_in_neo4j(claim_id, source_id, score)
+
+        expected_query = """
+        MATCH (claim:Claim {id: $claim_id})-[rel:ORIGINATES_FROM]->(block:Block {id: $source_id})
+        SET rel.entailed_score = $entailed_score
+        RETURN claim.id AS claimId, block.id AS blockId, rel.entailed_score AS updatedScore
+        """
+        params = {"claim_id": claim_id, "source_id": source_id, "entailed_score": score}
+        mock_graph_manager_fixture.execute_query.assert_called_once_with(
+            expected_query.strip(), parameters=params
+        )
+
+    def test_update_neo4j_score_is_none(
+        self, consumer_instance, mock_graph_manager_fixture
+    ):
+        claim_id, source_id = "c1", "s1"
+        mock_graph_manager_fixture.execute_query.return_value = [{"updatedScore": None}]
+
+        consumer_instance._update_entailment_score_in_neo4j(claim_id, source_id, None)
+
+        params = {"claim_id": claim_id, "source_id": source_id, "entailed_score": None}
+        mock_graph_manager_fixture.execute_query.assert_called_with(
+            pytest.ANY, parameters=params
+        )
+
+    @patch("aclarai_core.dirty_block_consumer.logger")  # Corrected
+    def test_update_neo4j_no_results(
+        self, mock_logger, consumer_instance, mock_graph_manager_fixture
+    ):
+        claim_id, source_id, score = "c1", "s1", 0.8
+        mock_graph_manager_fixture.execute_query.return_value = []
+
+        consumer_instance._update_entailment_score_in_neo4j(claim_id, source_id, score)
+
+        assert mock_logger.warning.called
+        assert "did not return results" in mock_logger.warning.call_args[0][0]
+
+    @patch("aclarai_core.dirty_block_consumer.logger")  # Corrected
+    def test_update_neo4j_exception(
+        self, mock_logger, consumer_instance, mock_graph_manager_fixture
+    ):
+        claim_id, source_id, score = "c1", "s1", 0.8
+        mock_graph_manager_fixture.execute_query.side_effect = Exception("DB error")
+
+        consumer_instance._update_entailment_score_in_neo4j(claim_id, source_id, score)
+
+        assert mock_logger.error.called
+        assert (
+            "Failed to update entailment score in Neo4j"
+            in mock_logger.error.call_args[0][0]
+        )
+
+    @patch(
+        "aclarai_shared.import_system.write_file_atomically"
+    )  # Corrected: patch where it's imported from
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_update_markdown_new_score(
+        self, mock_exists, mock_read_text, mock_write_atomic, consumer_instance
+    ):
+        source_filepath, source_block_id, score = "/fake/vault/test.md", "b1", 0.75
+        mock_exists.return_value = True
+        initial_content = f"Line 1\n<!-- aclarai:id={source_block_id} ver=1 -->\nLine 3"
+        mock_read_text.return_value = initial_content
+
+        consumer_instance._update_markdown_with_entailment_score(
+            source_filepath, source_block_id, score
+        )
+
+        expected_content = f"Line 1\n<!-- aclarai:id={source_block_id} ver=2 -->\n<!-- aclarai:entailed_score={score:.2f} -->\nLine 3"
+        mock_write_atomic.assert_called_once_with(
+            Path(source_filepath), expected_content
+        )
+
+    @patch("aclarai_shared.import_system.write_file_atomically")  # Corrected
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    def test_update_markdown_update_existing_score(
+        self, mock_exists, mock_read_text, mock_write_atomic, consumer_instance
+    ):
+        source_filepath, source_block_id, score = "/fake/vault/test.md", "b1", 0.88
+        mock_exists.return_value = True
+        initial_content = f"Line 1\n<!-- aclarai:id={source_block_id} ver=2 -->\n<!-- aclarai:entailed_score=0.50 -->\nLine 4"
+        mock_read_text.return_value = initial_content
+
+        consumer_instance._update_markdown_with_entailment_score(
+            source_filepath, source_block_id, score
+        )
+
+        expected_content = f"Line 1\n<!-- aclarai:id={source_block_id} ver=3 -->\n<!-- aclarai:entailed_score={score:.2f} -->\nLine 4"
+        mock_write_atomic.assert_called_once_with(
+            Path(source_filepath), expected_content
+        )
+
+    @patch("aclarai_shared.import_system.write_file_atomically")  # Corrected
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.exists")
+    @patch("aclarai_core.dirty_block_consumer.logger")  # Corrected
+    def test_update_markdown_block_id_not_found(
+        self,
+        mock_logger,
+        mock_exists,
+        mock_read_text,
+        mock_write_atomic,
+        consumer_instance,
+    ):
+        source_filepath, source_block_id, score = (
+            "/fake/vault/test.md",
+            "b_unknown",
+            0.75,
+        )
+        mock_exists.return_value = True
+        mock_read_text.return_value = "Some content without the target block ID."
+
+        consumer_instance._update_markdown_with_entailment_score(
+            source_filepath, source_block_id, score
+        )
+
+        mock_write_atomic.assert_not_called()
+        assert mock_logger.warning.called
+        assert (
+            "Could not find aclarai:id comment" in mock_logger.warning.call_args[0][0]
+        )
+
+    @patch("aclarai_shared.import_system.write_file_atomically")  # Corrected
+    @patch("pathlib.Path.exists")
+    @patch("aclarai_core.dirty_block_consumer.logger")  # Corrected
+    def test_update_markdown_file_not_found(
+        self, mock_logger, mock_exists, mock_write_atomic, consumer_instance
+    ):
+        source_filepath, source_block_id, score = (
+            "/fake/vault/nonexistent.md",
+            "b1",
+            0.75,
+        )
+        mock_exists.return_value = False
+
+        consumer_instance._update_markdown_with_entailment_score(
+            source_filepath, source_block_id, score
+        )
+
+        mock_write_atomic.assert_not_called()
+        assert mock_logger.error.called
+        assert "Markdown file not found" in mock_logger.error.call_args[0][0]
+
+    def test_get_claims_success(self, consumer_instance, mock_graph_manager_fixture):
+        source_block_id = "s1"
+        expected_claims = [
+            {"id": "c1", "text": "Claim 1"},
+            {"id": "c2", "text": "Claim 2"},
+        ]
+        mock_graph_manager_fixture.execute_query.return_value = expected_claims
+
+        claims = consumer_instance._get_claims_for_evaluation(source_block_id)
+
+        assert claims == expected_claims
+        expected_query = """
+        MATCH (claim:Claim)-[r:ORIGINATES_FROM]->(block:Block {id: $source_block_id})
+        WHERE r.entailed_score IS NULL OR claim.needs_reprocessing = true
+        RETURN claim.id AS id, claim.text AS text
+        """
+        mock_graph_manager_fixture.execute_query.assert_called_once_with(
+            expected_query.strip(), parameters={"source_block_id": source_block_id}
+        )
+
+    def test_get_claims_none_found(self, consumer_instance, mock_graph_manager_fixture):
+        source_block_id = "s1"
+        mock_graph_manager_fixture.execute_query.return_value = []
+
+        claims = consumer_instance._get_claims_for_evaluation(source_block_id)
+        assert claims == []
+
+    @patch("aclarai_core.dirty_block_consumer.logger")  # Corrected
+    def test_get_claims_neo4j_exception(
+        self, mock_logger, consumer_instance, mock_graph_manager_fixture
+    ):
+        source_block_id = "s1"
+        mock_graph_manager_fixture.execute_query.side_effect = Exception(
+            "DB connection error"
+        )
+
+        claims = consumer_instance._get_claims_for_evaluation(source_block_id)
+
+        assert claims == []
+        assert mock_logger.error.called
+        assert (
+            "Failed to fetch claims for evaluation" in mock_logger.error.call_args[0][0]
+        )
+
+
+class TestDirtyBlockConsumerProcessBlockIntegration:
+    @patch.object(DirtyBlockConsumer, "_read_block_from_file")
+    @patch.object(DirtyBlockConsumer, "_sync_block_with_graph")
+    @patch.object(DirtyBlockConsumer, "_get_claims_for_evaluation")
+    @patch.object(DirtyBlockConsumer, "_update_entailment_score_in_neo4j")
+    @patch.object(DirtyBlockConsumer, "_update_markdown_with_entailment_score")
+    def test_process_block_success_flow(
+        self,
+        mock_update_markdown,
+        mock_update_neo4j,
+        mock_get_claims,
+        mock_sync_graph,
+        mock_read_block,
+        consumer_instance,
+    ):
+        message = {
+            "aclarai_id": "s1",
+            "file_path": "test_file.md",
+            "change_type": "modified",
+        }
+        mock_block_data = {
+            "aclarai_id": "s1",
+            "semantic_text": "source text",
+            "version": 1,
+        }
+        mock_claim_data = [{"id": "c1", "text": "claim text"}]
+
+        mock_read_block.return_value = mock_block_data
+        mock_sync_graph.return_value = True
+        mock_get_claims.return_value = mock_claim_data
+        consumer_instance.entailment_agent.evaluate_entailment.return_value = (
+            0.9,
+            "success",
+        )
+
+        result = consumer_instance._process_dirty_block(message)
+
+        assert result is True
+        mock_read_block.assert_called_once_with(Path("test_file.md"), "s1")
+        mock_sync_graph.assert_called_once_with(mock_block_data, Path("test_file.md"))
+        mock_get_claims.assert_called_once_with("s1")
+        consumer_instance.entailment_agent.evaluate_entailment.assert_called_once_with(
+            claim_id="c1",
+            claim_text="claim text",
+            source_id="s1",
+            source_text="source text",
+        )
+        mock_update_neo4j.assert_called_once_with("c1", "s1", 0.9)
+        expected_filepath = str(Path(consumer_instance.vault_path) / "test_file.md")
+        mock_update_markdown.assert_called_once_with(expected_filepath, "s1", 0.9)
+
+    @patch.object(DirtyBlockConsumer, "_read_block_from_file")
+    @patch.object(DirtyBlockConsumer, "_sync_block_with_graph")
+    @patch.object(DirtyBlockConsumer, "_get_claims_for_evaluation")
+    @patch.object(DirtyBlockConsumer, "_update_entailment_score_in_neo4j")
+    @patch.object(DirtyBlockConsumer, "_update_markdown_with_entailment_score")
+    def test_process_block_entailment_agent_fails(
+        self,
+        mock_update_markdown,
+        mock_update_neo4j,
+        mock_get_claims,
+        mock_sync_graph,
+        mock_read_block,
+        consumer_instance,
+    ):
+        message = {
+            "aclarai_id": "s1",
+            "file_path": "test_file.md",
+            "change_type": "modified",
+        }
+        mock_block_data = {
+            "aclarai_id": "s1",
+            "semantic_text": "source text",
+            "version": 1,
+        }
+        mock_claim_data = [{"id": "c1", "text": "claim text"}]
+
+        mock_read_block.return_value = mock_block_data
+        mock_sync_graph.return_value = True
+        mock_get_claims.return_value = mock_claim_data
+        consumer_instance.entailment_agent.evaluate_entailment.return_value = (
+            None,
+            "LLM error",
+        )
+
+        result = consumer_instance._process_dirty_block(message)
+        assert result is True
+        mock_update_neo4j.assert_called_once_with("c1", "s1", None)
+        mock_update_markdown.assert_not_called()
+
+    @patch.object(DirtyBlockConsumer, "_read_block_from_file")
+    @patch.object(DirtyBlockConsumer, "_sync_block_with_graph")
+    @patch.object(DirtyBlockConsumer, "_get_claims_for_evaluation")
+    @patch.object(DirtyBlockConsumer, "_update_entailment_score_in_neo4j")
+    @patch.object(DirtyBlockConsumer, "_update_markdown_with_entailment_score")
+    def test_process_block_no_claims_for_evaluation(
+        self,
+        mock_update_markdown,
+        mock_update_neo4j,
+        mock_get_claims,
+        mock_sync_graph,
+        mock_read_block,
+        consumer_instance,
+    ):
+        message = {
+            "aclarai_id": "s1",
+            "file_path": "test_file.md",
+            "change_type": "modified",
+        }
+        mock_block_data = {
+            "aclarai_id": "s1",
+            "semantic_text": "source text",
+            "version": 1,
+        }
+
+        mock_read_block.return_value = mock_block_data
+        mock_sync_graph.return_value = True
+        mock_get_claims.return_value = []
+
+        result = consumer_instance._process_dirty_block(message)
+        assert result is True
+        consumer_instance.entailment_agent.evaluate_entailment.assert_not_called()
+        mock_update_neo4j.assert_not_called()
+        mock_update_markdown.assert_not_called()
+
+    def test_process_block_deleted_message(self, consumer_instance):
+        message = {
+            "aclarai_id": "s1",
+            "file_path": "test_file.md",
+            "change_type": "deleted",
+        }
+
+        with (
+            patch.object(consumer_instance, "_read_block_from_file") as mock_read,
+            patch.object(consumer_instance, "_sync_block_with_graph") as mock_sync,
+        ):
+            result = consumer_instance._process_dirty_block(message)
+            assert result is True
+            mock_read.assert_not_called()
+            mock_sync.assert_not_called()
+
+    @patch.object(DirtyBlockConsumer, "_read_block_from_file")
+    def test_process_block_read_file_fails(self, mock_read_block, consumer_instance):
+        message = {
+            "aclarai_id": "s1",
+            "file_path": "test_file.md",
+            "change_type": "modified",
+        }
+        mock_read_block.return_value = None
+
+        result = consumer_instance._process_dirty_block(message)
+        assert result is False
+
+    @patch.object(DirtyBlockConsumer, "_read_block_from_file")
+    @patch.object(DirtyBlockConsumer, "_sync_block_with_graph")
+    def test_process_block_sync_graph_fails(
+        self, mock_sync_graph, mock_read_block, consumer_instance
+    ):
+        message = {
+            "aclarai_id": "s1",
+            "file_path": "test_file.md",
+            "change_type": "modified",
+        }
+        mock_block_data = {
+            "aclarai_id": "s1",
+            "semantic_text": "source text",
+            "version": 1,
+        }
+
+        mock_read_block.return_value = mock_block_data
+        mock_sync_graph.return_value = False
+
+        result = consumer_instance._process_dirty_block(message)
+        assert result is False

--- a/shared/aclarai_shared/aclarai.config.default.yaml
+++ b/shared/aclarai_shared/aclarai.config.default.yaml
@@ -39,6 +39,24 @@ tools:
               similar to the input claim. This helps determine if the claim
               is ambiguous or relies on unstated context by checking if
               very similar phrases appear in diverse contexts.
+    entailment_agent:
+      - name: "Neo4jQueryTool"
+        params: {} # Uses default Neo4j connection
+        metadata:
+          name: "neo4j_query_tool"
+          description: >
+            Executes Cypher queries on the knowledge graph. Use this to
+            retrieve contextual information, such as surrounding conversation
+            blocks or related concepts, to better assess entailment.
+      - name: "VectorSearchTool"
+        params:
+          collection: "utterances" # Or another relevant collection
+        metadata:
+          name: "vector_search_utterances"
+          description: >
+            Searches for similar utterances or text segments in the knowledge base.
+            Use this to find supporting or contradictory evidence or to understand
+            the typical usage of phrases found in the source or claim.
     
     # Example for another agent that might need multiple tools:
     # some_other_agent:
@@ -86,6 +104,7 @@ model:
     selection: null      # Uses default if not specified
     disambiguation: null # Uses default if not specified  
     decomposition: null  # Uses default if not specified
+    entailment: null     # Uses default if not specified (e.g., gpt-3.5-turbo)
   concept_linker: "gpt-3.5-turbo"
   concept_summary: "gpt-4"
   subject_summary: "gpt-3.5-turbo"

--- a/shared/aclarai_shared/prompts/entailment_evaluation.yaml
+++ b/shared/aclarai_shared/prompts/entailment_evaluation.yaml
@@ -1,0 +1,52 @@
+# Entailment Evaluation Stage Prompt
+# Used to evaluate if a source text logically entails a claim.
+
+role: "entailment_evaluator"
+description: "Expert at evaluating the logical entailment between a source text and a hypothesis (claim)."
+
+system_prompt: |
+  You are an expert logician and fact evaluator. Your task is to determine if a given 'Source' text logically entails a 'Claim' (hypothesis).
+  Entailment means that if the Source is true, the Claim must also be true. The Claim should not introduce new information or make assumptions not explicitly supported by the Source.
+
+  Consider the following:
+  - Does the Claim directly follow from the information presented in the Source?
+  - Is all information in the Claim explicitly stated or strongly implied by the Source?
+  - Does the Claim make broader generalizations than the Source supports?
+  - Does the Claim introduce new entities, concepts, or relationships not mentioned in the Source?
+
+  To help you, you have access to the following tools:
+  - 'neo4j_query_tool': You can use this to execute Cypher queries on the knowledge graph. This might be useful to retrieve the surrounding conversation blocks linked to the source block's aclarai:id or to fetch definitions of concepts mentioned.
+  - 'vector_search_utterances': You can use this tool to search for similar utterances or text segments in the knowledge base. This could help find supporting or contradictory evidence or to understand the typical usage of phrases found in the source or claim.
+
+  Your primary analysis should be based on the provided Source and Claim. Use tools only if you determine that additional context from the knowledge graph is necessary to make an accurate entailment judgment.
+
+template: |
+  Premise (Source):
+  "{source_text}"
+
+  Hypothesis (Claim):
+  "{claim_text}"
+
+  Task:
+  1. Carefully analyze the 'Premise' (Source) and the 'Hypothesis' (Claim).
+  2. Determine if the Premise logically entails the Hypothesis.
+  3. Optionally, use the available tools if you need more context to make a decision.
+     For example, you might query Neo4j for the conversation around the source text, or search vectors for similar statements.
+     If you use a tool, briefly state your thought, the action (tool call), and the observation.
+  4. Based on your analysis, provide an entailment score as a single float between 0.0 and 1.0.
+     - 1.0 means the Premise perfectly entails the Hypothesis.
+     - 0.5 means the Premise partially supports or is related to the Hypothesis, but does not fully entail it.
+     - 0.0 means the Premise does not entail the Hypothesis at all, or contradicts it.
+
+  Output only the float score. For example: 0.91
+
+# Template variables that can be injected at runtime
+variables:
+  source_text:
+    type: "string"
+    description: "The source text (premise)."
+    required: true
+  claim_text:
+    type: "string"
+    description: "The claim text (hypothesis) to be evaluated for entailment by the source."
+    required: true


### PR DESCRIPTION
Implements an agent to evaluate the entailment of a claim by its source text. Includes comprehensive testing structure and robust LLM initialization.

Key changes:
- Added `EntailmentAgent` class using LlamaIndex `CodeActAgent`.
- Created `entailment_evaluation.yaml` prompt template.
- Updated default configuration for agent tools and model selection.
- Integrated `EntailmentAgent` into `DirtyBlockConsumer` for:
    - Fetching claims needing evaluation.
    - Calling the agent for `entailed_score`.
    - Storing score in Neo4j on `[:ORIGINATES_FROM]` relationship.
    - Updating source Markdown with score comment and incremented version.
- Revised `DirtyBlockConsumer._initialize_llm` to load actual configured LLMs, with error handling and MagicMock fallback for non-critical failures, removing direct MockLLM use in production code.
- Added component documentation: `docs/components/entailment_evaluation_agent.md`.
- Updated `docs/components/markdown_updater_system.md`.
- Implemented extensive unit tests for `EntailmentAgent` and relevant `DirtyBlockConsumer` methods.
- Added CI-friendly integration tests for `DirtyBlockConsumer._process_dirty_block` orchestration.
- Outlined further `@pytest.mark.integration` tests.
- Ensured all code passes linting and formatting.

Fixes #132 